### PR TITLE
Implement get item references

### DIFF
--- a/lib/podio/models/item.rb
+++ b/lib/podio/models/item.rb
@@ -137,6 +137,14 @@ class Podio::Item < ActivePodio::Base
       response.body
     end
 
+    # @see https://developers.podio.com/doc/items/get-item-references-22439
+    def find_references(item_id)
+      response = Podio.connection.get { |req|
+        req.url("/item/#{item_id}/reference/")
+      }
+      response.body
+    end            
+
     # @see https://developers.podio.com/doc/items/get-references-to-item-by-field-7403920
     def find_references_by_field(item_id, field_id, options = {})
       list Podio.connection.get { |req|


### PR DESCRIPTION
Hey,

I needed this method for a project I'm working on, and I couldn't find it in the ruby library, so I implemented it. https://developers.podio.com/doc/items/get-item-references-22439

I put the method in the Podio::Item class, and followed the preferred block syntax for the connection.  I also added a missing comment for the neighboring method :smile: 

Let me know if it looks good, or if I should change anything. 
In the meantime, I'm referencing my fork in my project.

Thanks!
