### PR TITLE
Added option argument for Item.find_by_filter_values

### DIFF
--- a/lib/podio/models/item.rb
+++ b/lib/podio/models/item.rb
@@ -138,10 +138,10 @@ class Podio::Item < ActivePodio::Base
     end
 
     # @see https://developers.podio.com/doc/items/filter-items-4496747
-    def find_by_filter_values(app_id, filter_values, attributes={})
+    def find_by_filter_values(app_id, filter_values, attributes={}, options={})
       attributes[:filters] = filter_values
       collection Podio.connection.post { |req|
-        req.url "/item/app/#{app_id}/filter/"
+        req.url("/item/app/#{app_id}/filter/", options)
         req.body = attributes
       }.body
     end


### PR DESCRIPTION
Hi Andreas, cfr to the podio help topic -> https://help.podio.com/hc/communities/public/questions/200519048-Podio-API-Why-don-t-item-files-appear-when-using-filter-?locale=en-us I'm filing a pull request to add an options argument to the find_by_filter_values. I tested everything. If there is anything I need to change, please say so.

Greetings,
PJ
