### PR TITLE
Faraday 0.9 compatibility and ActiveModel Update

### DIFF
--- a/lib/podio/client.rb
+++ b/lib/podio/client.rb
@@ -177,9 +177,7 @@ module Podio
     end
 
     def configure_connection
-      # binding.pry
-      Faraday::Connection.new(:url => api_url, :headers => configured_headers, :request => {:oauth => self}) do |builder|
-      # Faraday::Connection.new(:url => api_url, :headers => configured_headers, :client => self) do |builder|
+      Faraday::Connection.new(:url => api_url, :headers => configured_headers) do |builder|
         builder.use Middleware::JsonRequest
         builder.use Faraday::Request::Multipart
         builder.use Faraday::Request::UrlEncoded
@@ -200,7 +198,6 @@ module Podio
 
     def configure_oauth_connection
       conn = @connection.dup
-      conn.options[:oauth] = self
       conn.headers.delete('authorization')
       conn.headers.delete('X-Podio-Dry-Run') if @test_mode # oauth requests don't really work well in test mode
       conn
@@ -208,7 +205,6 @@ module Podio
 
     def configure_trusted_connection
       conn = @connection.dup
-      conn.options[:oauth] = self
       conn.headers.delete('authorization')
       conn.basic_auth(api_key, api_secret)
       conn

--- a/lib/podio/client.rb
+++ b/lib/podio/client.rb
@@ -177,7 +177,9 @@ module Podio
     end
 
     def configure_connection
-      Faraday::Connection.new(:url => api_url, :headers => configured_headers, :request => {:client => self}) do |builder|
+      # binding.pry
+      Faraday::Connection.new(:url => api_url, :headers => configured_headers, :request => {:oauth => self}) do |builder|
+      # Faraday::Connection.new(:url => api_url, :headers => configured_headers, :client => self) do |builder|
         builder.use Middleware::JsonRequest
         builder.use Faraday::Request::Multipart
         builder.use Faraday::Request::UrlEncoded

--- a/lib/podio/client.rb
+++ b/lib/podio/client.rb
@@ -200,7 +200,7 @@ module Podio
 
     def configure_oauth_connection
       conn = @connection.dup
-      conn.options[:client] = self
+      conn.options[:oauth] = self
       conn.headers.delete('authorization')
       conn.headers.delete('X-Podio-Dry-Run') if @test_mode # oauth requests don't really work well in test mode
       conn
@@ -208,7 +208,7 @@ module Podio
 
     def configure_trusted_connection
       conn = @connection.dup
-      conn.options[:client] = self
+      conn.options[:oauth] = self
       conn.headers.delete('authorization')
       conn.basic_auth(api_key, api_secret)
       conn

--- a/lib/podio/middleware/logger.rb
+++ b/lib/podio/middleware/logger.rb
@@ -7,7 +7,7 @@ module Podio
         # Preserve request body
         env[:request_body] = env[:body] if env[:body]
 
-        env[:request][:client].log(env) do
+        env[:request][:oauth].log(env) do
           @app.call(env)
         end
       end

--- a/lib/podio/middleware/logger.rb
+++ b/lib/podio/middleware/logger.rb
@@ -7,7 +7,7 @@ module Podio
         # Preserve request body
         env[:request_body] = env[:body] if env[:body]
 
-        env[:request][:oauth].log(env) do
+        Podio.client.log(env) do
           @app.call(env)
         end
       end

--- a/lib/podio/middleware/oauth2.rb
+++ b/lib/podio/middleware/oauth2.rb
@@ -4,16 +4,14 @@ module Podio
   module Middleware
     class OAuth2 < Faraday::Middleware
       def call(env)
-        podio_client = env[:request][:oauth]
         orig_env = env.dup
-
         begin
           @app.call(env)
         rescue TokenExpired
-          podio_client.refresh_access_token
+          Podio.client.refresh_access_token
 
           # new access token needs to be put into the header
-          orig_env[:request_headers].merge!(podio_client.configured_headers)
+          orig_env[:request_headers].merge!(Podio.client.configured_headers)
 
           # rewind the body if this was a file upload
           orig_env[:body].rewind if orig_env[:body].respond_to?(:rewind)

--- a/lib/podio/middleware/oauth2.rb
+++ b/lib/podio/middleware/oauth2.rb
@@ -4,7 +4,7 @@ module Podio
   module Middleware
     class OAuth2 < Faraday::Middleware
       def call(env)
-        podio_client = env[:request][:client]
+        podio_client = env[:request][:oauth]
         orig_env = env.dup
 
         begin

--- a/podio.gemspec
+++ b/podio.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
     s.add_dependency('activesupport', '~> 3.0')
     s.add_dependency('activemodel', '~> 3.0')
   else
-    s.add_dependency('activesupport', '>= 4.0')
-    s.add_dependency('activemodel', '>= 4.0')
+    s.add_dependency('activesupport', '>= 3.0')
+    s.add_dependency('activemodel', '>= 3.0')
   end
 
   s.add_development_dependency('rake')

--- a/podio.gemspec
+++ b/podio.gemspec
@@ -19,17 +19,18 @@ Gem::Specification.new do |s|
 
   s.has_rdoc          = false
 
-  s.add_dependency('faraday', '~> 0.8.0')
+  s.add_dependency('faraday', '~> 0.9.0')
   s.add_dependency('multi_json')
 
   if RUBY_VERSION < '1.9.3'
     s.add_dependency('activesupport', '~> 3.0')
     s.add_dependency('activemodel', '~> 3.0')
   else
-    s.add_dependency('activesupport', '>= 3.0')
-    s.add_dependency('activemodel', '>= 3.0')
+    s.add_dependency('activesupport', '>= 4.0')
+    s.add_dependency('activemodel', '>= 4.0')
   end
 
   s.add_development_dependency('rake')
   s.add_development_dependency('yard')
+  s.add_development_dependency('pry')
 end

--- a/podio.gemspec
+++ b/podio.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc          = false
 
-  s.add_dependency('faraday', '~> 0.9.0')
+  s.add_dependency('faraday', '>= 0.8.0')
   s.add_dependency('multi_json')
 
   if RUBY_VERSION < '1.9.3'

--- a/podio.gemspec
+++ b/podio.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('yard')
-  s.add_development_dependency('pry')
 end


### PR DESCRIPTION
Due to a version conflict with Faraday and ActiveModel I had to update podio-rb to make it work. Faraday 0.9 introduced a couple of breaking changes. 

The [Faraday Connection](https://github.com/lostisland/faraday/blob/v0.9.0/lib/faraday/connection.rb#L57-L63) creates an [Options Struct](https://github.com/lostisland/faraday/blob/v0.9.0/lib/faraday/options.rb#L31) with fixed attributes, rather than allowing a Hash that would store whatever is passed in. My first try was to piggyback on an existing attribute. That did work, but felt a bit messy. 

I then looked up how `Podio.client` obtains the client, and since it just pulls it out of `Thread.current`, why not use that directly and no longer pass the client object to Faraday.