### PR TITLE
added Podio::Item.item_count

### DIFF
--- a/lib/podio/models/item.rb
+++ b/lib/podio/models/item.rb
@@ -184,6 +184,11 @@ class Podio::Item < ActivePodio::Base
       }.body
     end
 
+    # @see https://developers.podio.com/doc/items/get-item-count-34819997
+    def item_count(app_id)
+      Podio.connection.get("/item/app/#{app_id}/count/").body
+    end
+
     # @see https://developers.podio.com/doc/items/get-items-as-xlsx-63233
     def xlsx(app_id, options={})
       response = Podio.connection.get { |req|


### PR DESCRIPTION
Get the total of items in an app, If prefered I can add the ['count'] at the end so that the method returns an integer instead of a hash with only one key...
