### PR TITLE
Updated faraday to 0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 script/config.rb
 *.swp
 .idea
+tags

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+* [Daniël W. Crompton](https://github.com/webhat)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2010-2011 Podio
+Copyright (c) 2014 Daniël W. Crompton <crompton@oplerno.com> Updated to support Faraday 0.9.0
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
 Copyright (c) 2010-2011 Podio
-Copyright (c) 2014 Daniël W. Crompton <crompton@oplerno.com> Updated to support Faraday 0.9.0
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/podio/middleware/logger.rb
+++ b/lib/podio/middleware/logger.rb
@@ -7,7 +7,7 @@ module Podio
         # Preserve request body
         env[:request_body] = env[:body] if env[:body]
 
-        env[:request][:client].log(env) do
+        Podio::Client.client.log(env) do
           @app.call(env)
         end
       end

--- a/lib/podio/middleware/oauth2.rb
+++ b/lib/podio/middleware/oauth2.rb
@@ -4,12 +4,12 @@ module Podio
   module Middleware
     class OAuth2 < Faraday::Middleware
       def call(env)
-        podio_client = env[:request][:client]
         orig_env = env.dup
 
         begin
           @app.call(env)
         rescue TokenExpired
+          podio_client = Podio::Client.client
           podio_client.refresh_access_token
 
           # new access token needs to be put into the header

--- a/podio.gemspec
+++ b/podio.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc          = false
 
-  s.add_dependency('faraday', '~> 0.8.0')
+  s.add_dependency('faraday', '~> 0.9.0')
   s.add_dependency('multi_json')
 
   if RUBY_VERSION < '1.9.3'


### PR DESCRIPTION
Due to a undocumented feature in faraday it was possible to pass objects around by using the `RequestOption` struct, like this:
```
    env[:request][:client] = self
```

This undocumented feature this broke as of 0.9.0.

I patched it using a singleton in the `Podio::Client`.