### PR TITLE
File and ExternaIFile

### DIFF
--- a/lib/podio/models/external_file.rb
+++ b/lib/podio/models/external_file.rb
@@ -18,7 +18,7 @@ class Podio::ExternalFile < ActivePodio::Base
       }.body
     end
 
-
+    # DEPRECATED please use FileAttachment.create_from_external_id
     def create_from_external_file_id(linked_account_id, external_file_id, preserve_permissions=false, options={})
       response = Podio.client.connection.post do |req|
         req.url("/file/linked_account/#{linked_account_id}/", options)

--- a/lib/podio/models/file_attachment.rb
+++ b/lib/podio/models/file_attachment.rb
@@ -1,6 +1,7 @@
 # @see https://developers.podio.com/doc/files
 class Podio::FileAttachment < ActivePodio::Base
   property :file_id, :integer
+  property :external_file_id, :integer
   property :link, :string
   property :link_target, :string
   property :perma_link, :string

--- a/lib/podio/models/file_attachment.rb
+++ b/lib/podio/models/file_attachment.rb
@@ -68,6 +68,18 @@ class Podio::FileAttachment < ActivePodio::Base
       member response.body
     end
 
+    def create_from_external_file_id(linked_account_id, external_file_id, preserve_permissions=false, options={})
+      response = Podio.client.connection.post do |req|
+        req.url("/file/linked_account/#{linked_account_id}/", options)
+        req.body = {
+            :external_file_id     => external_file_id,
+            :preserve_permissions => preserve_permissions
+        }
+      end
+
+      member response.body
+    end
+
     # Attach a file to an existing reference
     # @see https://developers.podio.com/doc/files/attach-file-22518
     def attach(id, ref_type, ref_id)


### PR DESCRIPTION
- Add property `external_file_id` to `FileAttachment`
- Add method `FileAttachment.create_from_external_file_id`
- Mark `ExternalFile.create_from_external_file_id` as deprecated. The API returns a `File` not an `ExternalFile`.