### PR TITLE
Bump faraday, and fix deprecation warning

### DIFF
--- a/lib/podio/client.rb
+++ b/lib/podio/client.rb
@@ -188,11 +188,11 @@ module Podio
         builder.use Middleware::OAuth2, :podio_client => self
         builder.use Middleware::Logger, :podio_client => self
 
-        builder.adapter(*default_adapter)
-
         # first response middleware defined get's executed last
         builder.use Middleware::ErrorResponse
         builder.use Middleware::JsonResponse
+
+        builder.adapter(*default_adapter)
       end
     end
 

--- a/podio.gemspec
+++ b/podio.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc          = false
 
-  s.add_dependency('faraday', ['>= 0.8.0', '< 0.10.0'])
+  s.add_dependency('faraday', ['>= 0.8.0', '< 0.16.0'])
   s.add_dependency('multi_json')
 
   if RUBY_VERSION < '1.9.3'

--- a/podio.gemspec
+++ b/podio.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths     = ['lib']
 
-  s.has_rdoc          = false
-
   s.add_dependency('faraday', ['>= 0.8.0', '< 0.16.0'])
   s.add_dependency('multi_json')
 


### PR DESCRIPTION
Allow newer faraday (tested as working in production for almost a year now), and also don't register and faraday middlewares after the adapter is registered (or else newer faraday complains with a deprecation warning).