### PR TITLE
Revert "Added authentication for SAML SSO."

### DIFF
--- a/lib/podio/client.rb
+++ b/lib/podio/client.rb
@@ -106,19 +106,6 @@ module Podio
       [@oauth_token, response.body['new_user_created']]
     end
 
-    # Sign in with SAML SSO
-    if show_feature?(:sso_saml)
-      def authenticate_with_saml(attributes)
-        response = @oauth_connection.post do |req|
-          req.url '/oauth/token', :grant_type => 'saml', :client_id => SETTINGS.podio_api.default_client.api_key, :client_secret => SETTINGS.podio_api.default_client.api_secret
-          req.body = attributes
-        end
-        @oauth_token = OAuthToken.new(response.body)
-        configure_oauth
-        @oauth_token
-      end
-    end
-    
     # Sign in with an OpenID, only available for Podio
     def authenticate_with_openid(identifier, type)
       response = @trusted_connection.post do |req|


### PR DESCRIPTION
Reverts podio/podio-rb#55

The [builds](https://travis-ci.org/podio/podio-rb/builds/536599989?utm_source=github_status&utm_medium=notification) are failing and the pull request was merged without approvals.
