### PR TITLE
POD-1367: Marketo cleanup (lib)

### DIFF
--- a/lib/podio/models/user.rb
+++ b/lib/podio/models/user.rb
@@ -24,7 +24,6 @@ class Podio::User < ActivePodio::Base
   property :landing, :string
   property :referrer, :string
   property :internal, :hash
-  property :marketo_cookie, :string
 
   alias_method :id, :user_id
 


### PR DESCRIPTION
# WHAT
- Removed Marketo reference

# WHY
POD-1372
POD-1367

# RISK
low.

# TESTING
local