### PR TITLE
Upgrade faraday range to <=1.3.0

### DIFF
--- a/podio.gemspec
+++ b/podio.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc          = false
 
-  s.add_dependency('faraday', ['>= 0.8.0', '< 0.10.0'])
+  s.add_dependency('faraday', ['>= 0.8.0', '<= 1.3.0'])
   s.add_dependency('multi_json')
 
   if RUBY_VERSION < '1.9.3'


### PR DESCRIPTION
# WHAT 
We need to upgrade faraday on frontend-webforms to version 1.3.0. This PR only extends the acceptable range of versions of Faraday to include upto version 1.3.0

#WHY 
POD-2440

# TESTING
docker tested

# RISK 
NA