### PR TITLE
[POD-5194] - Fetch Shared Grants for "Shared with me" filter tab by ref_type

### DIFF
--- a/lib/podio/models/grant.rb
+++ b/lib/podio/models/grant.rb
@@ -70,6 +70,7 @@ class Podio::Grant < ActivePodio::Base
       }.body
     end
 
+    # https://podio.com/podio/api/apps/api-operations/items/920
     def find_own_on_org_by_ref(org_id, ref_type, options = {})
       list Podio.connection.get { |req|
         req.url("/grant/org/#{org_id}/#{ref_type}/own/", options)

--- a/lib/podio/models/grant.rb
+++ b/lib/podio/models/grant.rb
@@ -70,5 +70,11 @@ class Podio::Grant < ActivePodio::Base
       }.body
     end
 
+    def find_own_on_org_by_ref(org_id, ref_type, options = {})
+      list Podio.connection.get { |req|
+        req.url("/grant/org/#{org_id}/#{ref_type}/own/", options)
+      }.body
+    end
+
   end
 end


### PR DESCRIPTION
# WHAT

- Consume new api which returns shared grants data by ref_type to populate data in `shared with me` filter tab

# WHY
https://issues.citrite.net/browse/POD-5194

# RISK
low - The functionality remains same, fetching data by ref_type

# TESTING
local