### PR TITLE
User management page (org member nil object fix)

### DIFF
--- a/lib/podio/models/organization_member.rb
+++ b/lib/podio/models/organization_member.rb
@@ -10,7 +10,7 @@ class Podio::OrganizationMember < ActivePodio::Base
   has_one :contact, :class => 'Contact', :property => :profile
 
   delegate :user_id, :mail, :domain, :is_partner, :to => :user
-  delegate :name, :avatar, :link, :title, :organization, :title_and_org, :default_title, :last_seen_on, :to => :contact
+  delegate :name, :avatar, :link, :title, :organization, :title_and_org, :default_title, :last_seen_on, :to => :contact, allow_nil: true
 
   def partner?
     return false if employee


### PR DESCRIPTION
Org Admins in podio can see User management page which shows all members in an org, but even if 1 member has a an avatar in their profile and the corresponding image fileID is missing in FILE DB table, then the entire page does not load because of uncaught exception in Rails code. 

This fix will ensure certain properties of the contact object are allowed to be nil and error will not be thrown on encountreing such nil objects

ticket: https://issues.sharefile-coretools.com/browse/POD-6485